### PR TITLE
Fix single ground run bug

### DIFF
--- a/src/nonogram_hints/core.clj
+++ b/src/nonogram_hints/core.clj
@@ -17,7 +17,7 @@
         ; Pad the array so there is at least one entry for figure and
         ; ground counts.
         (if (= 0 (count acc))
-            [0 0]
+            [cnt 0]
             (conj acc cnt))
         (if (not= curr-seq-value (first a))
             (recur (rest a) 1 (first a) (conj acc cnt))


### PR DESCRIPTION
There was a bug where a single run of ground pixels would be reported as
0 rather than the correct value. This change fixes that.